### PR TITLE
fix warp for compliation of all dcn operations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "iostream": "cpp"
+    }
+}

--- a/my_test_3d.py
+++ b/my_test_3d.py
@@ -1,0 +1,46 @@
+from modulated_deform_conv import *
+import ipdb
+print_tensor = lambda n, x: print(n, type(x), x.dtype, x.shape, x.min(), x.max())
+
+batch_size=1
+cpudata=torch.ones(batch_size,1,5,5,5, requires_grad=True)
+# data=torch.ones(batch,1,5,5,device='cuda',requires_grad=True)
+data=cpudata.cuda()
+
+offset=torch.zeros(batch_size,81,5,5,5, device='cuda',requires_grad=True) # 3**3 kernel_size, *3 dims
+mask=torch.ones(batch_size,27,5,5,5, device='cuda',requires_grad=True) # 3**3 kernel_size,
+weight=torch.ones(1,1,3,3,3,device='cuda',requires_grad=True)
+bias=torch.zeros(1,device='cuda',requires_grad=True)
+
+print_tensor('input', data)
+print_tensor('offset', offset)
+print_tensor('mask', mask)
+print_tensor('weight', weight)
+
+stride=1
+padding=1
+dilation=1
+groups=1
+deformable_groups=1
+in_step=64
+'''
+class DeformConv2dFunction(Function):
+    @staticmethod
+    def forward(ctx, input, offset, weight, bias=None, stride=1, padding=0, dilation=1,
+                groups=1, deformable_groups=1 , in_step=64):
+'''
+# out=deform_conv3d(data,offset,weight,bias,stride,padding,dilation,groups,deformable_groups,in_step)
+out=modulated_deform_conv3d(data,offset,mask,weight,bias,stride,padding,dilation,groups,deformable_groups,in_step)
+print_tensor('out', out)
+
+loss=out.sum()
+print(loss)
+# ipdb.set_trace()
+# print(data.grad)
+# print(offset.grad)
+# print(weight.grad)
+# print(bias.grad)
+loss.backward()
+# print(data.grad)
+# print(cpudata.grad)
+# print(bias.grad)

--- a/src/mdeformable_conv.cu
+++ b/src/mdeformable_conv.cu
@@ -120,7 +120,7 @@ void modulated_deform_conv2d_im2col_cuda(
 at::Tensor modulated_deform_conv2d_forward_cuda(
     at::Tensor input, at::Tensor weight, at::Tensor bias,
     at::Tensor offset, at::Tensor mask,
-    const int kernel_h,const int kernel_w,const const int stride_h, const int stride_w,
+    const int kernel_h,const int kernel_w, const int stride_h, const int stride_w,
     const int pad_h, const int pad_w, const int dilation_h,const int dilation_w,
     const int group, const int deformable_group,const int in_step,
     const bool with_bias) {
@@ -457,12 +457,12 @@ py::tuple modulated_deform_conv2d_backward_cuda(
   return out;
 }
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("modulated_deform_conv2d_forward_cuda", &modulated_deform_conv2d_forward_cuda,
-        "modulated_deform_conv2d_forward_cuda");
-  m.def("modulated_deform_conv2d_backward_cuda", &modulated_deform_conv2d_backward_cuda,
-        "modulated_deform_conv2d_backward_cuda");
-}
+// PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+//   m.def("modulated_deform_conv2d_forward_cuda", &modulated_deform_conv2d_forward_cuda,
+//         "modulated_deform_conv2d_forward_cuda");
+//   m.def("modulated_deform_conv2d_backward_cuda", &modulated_deform_conv2d_backward_cuda,
+//         "modulated_deform_conv2d_backward_cuda");
+// }
 
 
 

--- a/src/warp.cpp
+++ b/src/warp.cpp
@@ -1,19 +1,98 @@
-// #include <torch/extension.h>
-// 
-// 
-// PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-//   m.def("deform_conv2d_forward_cuda", &deform_conv2d_forward_cuda,
-//         "deform_conv2d_forward_cuda");
-//   m.def("deform_conv2d_backward_cuda", &deform_conv2d_backward_cuda,
-//         "deform_conv2d_backward_cuda");
-// 
-//   m.def("deform_conv3d_forward_cuda", &deform_conv3d_forward_cuda,
-//         "deform_conv3d_forward_cuda");
-//   m.def("deform_conv3d_backward_cuda", &deform_conv3d_backward_cuda,
-//         "deform_conv3d_backward_cuda");
-// 
-//   m.def("modulated_deform_conv3d_forward_cuda", &modulated_deform_conv3d_forward_cuda,
-//         "modulated_deform_conv3d_forward_cuda");
-//   m.def("modulated_deform_conv3d_backward_cuda", &modulated_deform_conv3d_backward_cuda,
-//         "modulated_deform_conv3d_backward_cuda");
-// }
+#include <torch/extension.h>
+//#include <ATen/ATen.h>
+// #include <THC/THCAtomics.cuh> # would fail the complilation process
+#include <pybind11/pybind11.h>
+
+int deform_conv2d_forward_cuda(
+    at::Tensor input, at::Tensor weight, at::Tensor bias,
+    at::Tensor offset, at::Tensor output,
+    const int kernel_h,const int kernel_w, const int stride_h, const int stride_w,
+    const int pad_h, const int pad_w, const int dilation_h,const int dilation_w,
+    const int group, const int deformable_group,const int in_step,
+    const bool with_bias);
+
+int deform_conv2d_backward_cuda(
+    at::Tensor input, at::Tensor weight, at::Tensor bias,at::Tensor offset,
+    at::Tensor grad_input, at::Tensor grad_weight, at::Tensor grad_bias,
+    at::Tensor grad_offset, at::Tensor grad_output,
+    const int kernel_h,const int kernel_w,const int stride_h,const int stride_w,
+    const int pad_h,const int pad_w,const int dilation_h,const int dilation_w,
+    const int group,const int deformable_group, const int in_step,const bool with_bias);
+
+at::Tensor modulated_deform_conv2d_forward_cuda(
+    at::Tensor input, at::Tensor weight, at::Tensor bias,
+    at::Tensor offset, at::Tensor mask,
+    const int kernel_h,const int kernel_w, const int stride_h, const int stride_w,
+    const int pad_h, const int pad_w, const int dilation_h,const int dilation_w,
+    const int group, const int deformable_group,const int in_step,
+    const bool with_bias);
+
+pybind11::tuple modulated_deform_conv2d_backward_cuda(
+    at::Tensor input, at::Tensor weight, at::Tensor bias,at::Tensor offset, at::Tensor mask,
+    at::Tensor grad_output,
+    const int kernel_h,const int kernel_w,const int stride_h,const int stride_w,
+    const int pad_h,const int pad_w,const int dilation_h,const int dilation_w,
+    const int group,const int deformable_group, const int in_step,const bool with_bias);
+
+int deform_conv3d_forward_cuda(
+		at::Tensor input, at::Tensor weight,at::Tensor bias,
+        at::Tensor offset, at::Tensor output,
+        const int kernel_h,const int kernel_w,const int kernel_l,
+        const int stride_h,const int stride_w,const int stride_l,
+        const int pad_h,const int pad_w,const int pad_l,
+        const int dilation_h,const int dilation_w,const int dilation_l,
+        const int group,const int deformable_group, const int in_step,const bool with_bias);
+
+    
+int deform_conv3d_backward_cuda(
+    at::Tensor input, at::Tensor weight, at::Tensor bias,at::Tensor offset,
+    at::Tensor grad_input, at::Tensor grad_weight, at::Tensor grad_bias,
+    at::Tensor grad_offset, at::Tensor grad_output,
+    const int kernel_h,const int kernel_w,const int kernel_l,
+    const int stride_h,const int stride_w,const int stride_l,
+    const int pad_h,const int pad_w,const int pad_l,
+    const int dilation_h,const int dilation_w,const int dilation_l,
+    const int group, int deformable_group,const int in_step,const bool with_bias);
+
+int modulated_deform_conv3d_forward_cuda(
+    at::Tensor input, at::Tensor weight, at::Tensor bias,
+    at::Tensor offset, at::Tensor mask, at::Tensor output,
+    const int kernel_h, const int kernel_w, const int kernel_l,
+    const int stride_h, const int stride_w, const int stride_l,
+    const int pad_h, const int pad_w, const int pad_l,
+    const int dilation_h,const int dilation_w, const int dilation_l,
+    const int group, const int deformable_group,const int in_step,const bool with_bias);
+
+
+int modulated_deform_conv3d_backward_cuda(
+    at::Tensor input, at::Tensor weight, at::Tensor bias,at::Tensor offset,at::Tensor mask,
+    at::Tensor grad_input, at::Tensor grad_weight, at::Tensor grad_bias,
+    at::Tensor grad_offset, at::Tensor grad_mask, at::Tensor grad_output,
+    const int kernel_h,const int kernel_w,const int kernel_l,
+    const int stride_h,const int stride_w,const int stride_l,
+    const int pad_h,const int pad_w,const int pad_l,
+    const int dilation_h,const int dilation_w,const int dilation_l,
+    const int group,const int deformable_group,const int in_step,const bool with_bias);
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("deform_conv2d_forward_cuda", &deform_conv2d_forward_cuda,
+        "deform_conv2d_forward_cuda");
+  m.def("deform_conv2d_backward_cuda", &deform_conv2d_backward_cuda,
+        "deform_conv2d_backward_cuda");
+
+  m.def("modulated_deform_conv2d_forward_cuda", &modulated_deform_conv2d_forward_cuda,
+        "modulated_deform_conv2d_forward_cuda");
+  m.def("modulated_deform_conv2d_backward_cuda", &modulated_deform_conv2d_backward_cuda,
+        "modulated_deform_conv2d_backward_cuda");
+
+  m.def("deform_conv3d_forward_cuda", &deform_conv3d_forward_cuda,
+        "deform_conv3d_forward_cuda");
+  m.def("deform_conv3d_backward_cuda", &deform_conv3d_backward_cuda,
+        "deform_conv3d_backward_cuda");
+
+  m.def("modulated_deform_conv3d_forward_cuda", &modulated_deform_conv3d_forward_cuda,
+        "modulated_deform_conv3d_forward_cuda");
+  m.def("modulated_deform_conv3d_backward_cuda", &modulated_deform_conv3d_backward_cuda,
+        "modulated_deform_conv3d_backward_cuda");
+}


### PR DESCRIPTION
With original repo, compilation results in only modulated_deform_conv2d operations and other three are inaccessible. 
This update fixed the issue and made all dcn operations available for python usage. 
The credits still go to the original author. Thank you. 